### PR TITLE
load echarts conditionally

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -4,7 +4,14 @@ import { sampleRUM } from './lib-franklin.js';
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
 
-const echartScript = document.createElement('script');
-echartScript.type = 'text/javascript';
-echartScript.src = 'https://cdn.jsdelivr.net/npm/echarts@5.4.2/dist/echarts.min.js';
-document.head.appendChild(echartScript);
+// load echarts library unless the page metadata says otherwise
+let loadecharts = true;
+if (document.querySelector('meta[name="echarts"]') && document.querySelector('meta[name="echarts"]').content === 'false') {
+  loadecharts = false;
+}
+if (loadecharts) {
+  const echartScript = document.createElement('script');
+  echartScript.type = 'text/javascript';
+  echartScript.src = 'https://cdn.jsdelivr.net/npm/echarts@5.4.2/dist/echarts.min.js';
+  document.head.appendChild(echartScript);
+}


### PR DESCRIPTION
Allow pages to not load echarts when not needed.  A metadata block on the page with a tag named echarts and value of false is all that is needed

Fix #27

Test URLs:
- Before: https://datalist--franklin-dashboard--adobe.hlx.live/screens/experimental/no-echarts
- After: https://datalist-echartsoptional--franklin-dashboard--adobe.hlx.live/screens/experimental/no-echarts
