### PR TITLE
Datalist style

### DIFF
--- a/blocks/charts/charts.js
+++ b/blocks/charts/charts.js
@@ -1,5 +1,5 @@
 import { readBlockConfig } from '../../scripts/lib-franklin.js';
-import { drawLoading } from '../../scripts/loading.js';
+// import { drawLoading } from '../../scripts/loading.js';
 import { getQueryInfo, queryRequest, getUrlBase } from '../../scripts/scripts.js';
 import LineChart from './linecharts/lineChart.js';
 import BarChart from './barcharts/barCharts.js';

--- a/blocks/list/list.css
+++ b/blocks/list/list.css
@@ -1,19 +1,22 @@
 div.grid.list.container {
     display: grid;
+    grid-gap: 0.2em;
+    width: 100%;
+
+    /*
     position: sticky;
     top: 0;
-    grid-gap: 1em;
     background-color: var(--overlay-background-color);
     height: 100vh;
-    width: 100%;
     overflow: scroll;
+    */
 }
 
-.list-container{
+.list-container {
     height: 100%;
 }
 
-.list-wrapper{
+.list-wrapper {
     height: 100%;
 }
 
@@ -26,17 +29,25 @@ div.grid.list.row {
     justify-items: center;
 }
 
-div.grid.list.row:not(.heading){
-    border-radius: 10px;
+div.grid.list.row:not(.heading) {
+    /* border-radius: 10px; */
     border-color: black;
     font-size:var(--body-font-size-m);
 }
 
 div.grid.list.row.heading {
+    /*
     position: -webkit-sticky;
     position: sticky;
     top: 0;
     background-color:grey;
+    */
+    font-weight: bold;
+    background-color: var(--highlight-background-color);
+}
+
+div.grid.list.row.odd {
+    background-color: var(--overlay-background-color);
 }
 
 div.grid.list.col {
@@ -50,8 +61,8 @@ div.grid.list.col {
     align-items: center;
 }
 
-div.grid.list.col:not(.url, .usrexp, .heading, .avgcls, .avginp, .avglcp, .avgfid){
-    background-color: grey;
+div.grid.list.col:not(.url, .usrexp, .heading, .avgcls, .avginp, .avglcp, .avgfid) {
+    background-color: var(--highlight-background-color);
 }
 
 div.grid.list.col.url {
@@ -60,23 +71,24 @@ div.grid.list.col.url {
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+
+    /*
     border-bottom: 1px;
     border-bottom-style: solid;
+    */
 }
 
 .usrexp {
     text-overflow: unset;
     white-space: unset;
     overflow: unset;
-}
-
-.usrexp {
     display: flex;
     flex-direction:row;
     width: 100%;
-    height: 30px;
     background-color: #b3b3b3;
     color: white;
+
+    /* height: 30px; */
 }
 
 .goodbar {
@@ -89,6 +101,7 @@ div.grid.list.col.url {
 .okaybar {
     height: 100%;
     background-color: orange;
+    color: black;
     text-align: center;
     font-size: medium;
 }
@@ -105,6 +118,7 @@ div.grid.list.col.url {
     width: 100%;
     background-repeat: no-repeat;
     background-color: red;
+    color: white;
 }
 
 .pass {
@@ -112,6 +126,7 @@ div.grid.list.col.url {
     width: 100%;
     background-repeat: no-repeat;
     background-color: green;
+    color: white;
 }
 
 .okay {
@@ -124,14 +139,17 @@ div.grid.list.col.url {
 .loader {
     /* align-items: center; */
     margin: auto;
+    
     /* justify-content: center; */
+
     /* position: absolute; */
     width: calc(100px - 24px);
     height: 50vh;
     position: relative;
     animation: flippx 2s infinite linear;
   }
-  .loader:before {
+
+.loader::before {
     content: "";
     position: absolute;
     inset: 0;
@@ -142,8 +160,9 @@ div.grid.list.col.url {
     background:red;
     transform-origin: -24px 50%;
     animation: spin 1s infinite linear;
-  }
-  .loader:after {
+}
+
+.loader::after {
     content: "";
     position: absolute;
     left: 50%;
@@ -153,20 +172,25 @@ div.grid.list.col.url {
     width: 48px;
     height: 48px;
     border-radius: 50%;
-  }
+}
   
-  @keyframes flippx {
+@keyframes flippx {
     0%, 49% {
       transform: scaleX(1);
     }
+
     50%, 100% {
       transform: scaleX(-1);
     }
-  }
-  @keyframes spin {
+}
+
+@keyframes spin {
     100% {
       transform: rotate(360deg);
     }
-  }
+}
 
-  
+div.section.list-container p {
+    font-size: var(--body-font-size-s);
+    margin-top: 0;
+}

--- a/blocks/list/list.css
+++ b/blocks/list/list.css
@@ -109,6 +109,7 @@ div.grid.list.col.url {
 .badbar {
     height: 100%;
     background-color: red;
+    color: black;
     text-align: center;
     font-size: medium;
 }
@@ -118,7 +119,6 @@ div.grid.list.col.url {
     width: 100%;
     background-repeat: no-repeat;
     background-color: red;
-    color: white;
 }
 
 .pass {

--- a/blocks/list/list.js
+++ b/blocks/list/list.js
@@ -2,11 +2,12 @@ import { readBlockConfig } from '../../scripts/lib-franklin.js';
 import { getQueryInfo, queryRequest, getUrlBase } from '../../scripts/scripts.js';
 
 export default function decorate(block) {
-  const perfRanges = {};
+  // const perfRanges = {};
 
   let cfg = readBlockConfig(block);
   cfg = Object.fromEntries(Object.entries(cfg).map(([k, v]) => [k, typeof v === 'string' ? v.toLowerCase() : v]));
   const endpoint = cfg.data;
+  /*
   if (Object.hasOwn(cfg, 'good') && Object.hasOwn(cfg, 'okay') && Object.hasOwn(cfg, 'poor')) {
     perfRanges[tableColumn] = {
       good: cfg.good.replace(' ', '').split(',').map((el) => parseFloat(el)),
@@ -14,9 +15,10 @@ export default function decorate(block) {
       poor: cfg.poor.replace(' ', '').split(',').map((el) => parseFloat(el)),
     };
   }
+  */
 
   cfg.block = block;
-  cfg.perfRanges = perfRanges;
+  // cfg.perfRanges = perfRanges;
   const flag = `${endpoint}Flag`;
 
   // once we read config, clear the dom.
@@ -40,13 +42,15 @@ export default function decorate(block) {
 
   const makeList = () => {
     if ((Object.hasOwn(window, flag) && window[flag] === true) || !Object.hasOwn(window, flag)) {
-      window.setTimeout(makeList, 3000);
+      window.setTimeout(makeList, 2000);
     } else if (Object.hasOwn(window, flag) && window[flag] === false) {
       // query complete, hide loading graphic
       const { data } = window.dashboard[endpoint].results;
+      /*
       document.querySelectorAll('div.loading').forEach((loading) => {
         loading.style.display = 'none';
       });
+      */
 
       const listGridContainer = document.createElement('div');
       listGridContainer.classList.add('grid', 'list', 'container');
@@ -77,7 +81,7 @@ export default function decorate(block) {
         } else if (cols[j] === 'avgfid') {
           listGridHeadings.textContent = 'Avg FID';
         } else if (cols[j] === 'avginp') {
-          listGridHeadings.textContent = 'Avg FID';
+          listGridHeadings.textContent = 'Avg INP';
         } else {
           listGridHeadings.textContent = cols[j];
         }
@@ -134,6 +138,8 @@ export default function decorate(block) {
               txtContent = data[i][cols[j]] / 1000.00;
             } else if (cols[j] === 'url') {
               listGridColumn.innerHTML = `<a href='${data[i][cols[j]]}' target="_blank">${data[i][cols[j]].replace(/^https?:\/\/[^/]+/i, '')}</a>`;
+            } else if (cols[j] === 'pageviews') {
+              txtContent = parseInt(data[i][cols[j]], 10).toLocaleString('en-US');
             } else {
               txtContent = data[i][cols[j]];
             }

--- a/blocks/list/list.js
+++ b/blocks/list/list.js
@@ -42,7 +42,7 @@ export default function decorate(block) {
 
   const makeList = () => {
     if ((Object.hasOwn(window, flag) && window[flag] === true) || !Object.hasOwn(window, flag)) {
-      window.setTimeout(makeList, 2000);
+      window.setTimeout(makeList, 3000);
     } else if (Object.hasOwn(window, flag) && window[flag] === false) {
       // query complete, hide loading graphic
       const { data } = window.dashboard[endpoint].results;

--- a/blocks/list/list.js
+++ b/blocks/list/list.js
@@ -46,6 +46,9 @@ export default function decorate(block) {
     } else if (Object.hasOwn(window, flag) && window[flag] === false) {
       // query complete, hide loading graphic
       const { data } = window.dashboard[endpoint].results;
+      const main = document.querySelector('main');
+      const loader = main.querySelector('.loader');
+      loader.remove();
       /*
       document.querySelectorAll('div.loading').forEach((loading) => {
         loading.style.display = 'none';

--- a/blocks/list/list.js
+++ b/blocks/list/list.js
@@ -42,7 +42,7 @@ export default function decorate(block) {
 
   const makeList = () => {
     if ((Object.hasOwn(window, flag) && window[flag] === true) || !Object.hasOwn(window, flag)) {
-      window.setTimeout(makeList, 3000);
+      window.setTimeout(makeList, 1000);
     } else if (Object.hasOwn(window, flag) && window[flag] === false) {
       // query complete, hide loading graphic
       const { data } = window.dashboard[endpoint].results;

--- a/blocks/list/list.js
+++ b/blocks/list/list.js
@@ -32,7 +32,7 @@ export default function decorate(block) {
       window.setTimeout(getQuery, 1);
     } else if (Object.hasOwn(window, 'gettingQueryInfo') && window.gettingQueryInfo === false) {
       queryRequest(cfg, getUrlBase(endpoint));
-      let loaderSpan = document.createElement('div');
+      const loaderSpan = document.createElement('div');
       loaderSpan.className = 'loader';
       block.append(loaderSpan);
     }
@@ -40,34 +40,45 @@ export default function decorate(block) {
 
   const makeList = () => {
     if ((Object.hasOwn(window, flag) && window[flag] === true) || !Object.hasOwn(window, flag)) {
-      window.setTimeout(makeList, 5);
+      window.setTimeout(makeList, 3000);
     } else if (Object.hasOwn(window, flag) && window[flag] === false) {
       // query complete, hide loading graphic
-      let data = window.dashboard[endpoint].results.data;
+      const { data } = window.dashboard[endpoint].results;
       document.querySelectorAll('div.loading').forEach((loading) => {
         loading.style.display = 'none';
       });
 
-      let listGridContainer = document.createElement('div');
-      listGridContainer.classList.add('grid', 'list', 'container')
+      const listGridContainer = document.createElement('div');
+      listGridContainer.classList.add('grid', 'list', 'container');
 
-      let cols = ['url', 'pageviews', 'usrexp', 'avglcp', 'avgcls', 'avgfid', 'avginp'];
-      let metrics = ['s', '', 'ms', 'ms'];
-      let ranges = {
+      const cols = ['url', 'pageviews', 'usrexp', 'avglcp', 'avgcls', 'avgfid', 'avginp'];
+      const metrics = ['s', '', 'ms', 'ms'];
+      const ranges = {
         avglcp: [2500, 4000],
         avgfid: [100, 300],
         avginp: [200, 500],
-        avgcls: [0.1, 0.25]
-      }
+        avgcls: [0.1, 0.25],
+      };
 
-      let listGridHeadingRow = document.createElement('div');
+      const listGridHeadingRow = document.createElement('div');
       listGridHeadingRow.classList.add('grid', 'list', 'row', 'heading');
-      for(let j = 0; j < 7; j++){
-        let listGridHeadings = document.createElement('div');
-        if(cols[j] === 'usrexp'){
-          listGridHeadings.textContent = '% of visits with good, okay, or bad CWV scores'
-        }
-        else{
+      for (let j = 0; j < 7; j += 1) {
+        const listGridHeadings = document.createElement('div');
+        if (cols[j] === 'usrexp') {
+          listGridHeadings.textContent = 'Core Web Vitals across visits';
+        } else if (cols[j] === 'url') {
+          listGridHeadings.textContent = 'Path';
+        } else if (cols[j] === 'pageviews') {
+          listGridHeadings.textContent = 'Page Views';
+        } else if (cols[j] === 'avglcp') {
+          listGridHeadings.textContent = 'Avg LCP';
+        } else if (cols[j] === 'avgcls') {
+          listGridHeadings.textContent = 'Avg CLS';
+        } else if (cols[j] === 'avgfid') {
+          listGridHeadings.textContent = 'Avg FID';
+        } else if (cols[j] === 'avginp') {
+          listGridHeadings.textContent = 'Avg FID';
+        } else {
           listGridHeadings.textContent = cols[j];
         }
         listGridHeadings.classList.add('grid', 'list', 'col', 'heading');
@@ -75,70 +86,73 @@ export default function decorate(block) {
       }
       listGridContainer.appendChild(listGridHeadingRow);
 
-      for(let i = 0; i < data.length; i++){
-        let listGridRow = document.createElement('div');
+      for (let i = 0; i < data.length; i += 1) {
+        const listGridRow = document.createElement('div');
         listGridRow.classList.add('grid', 'list', 'row');
-        const { lcpgood, lcpbad, clsgood, clsbad, fidgood, fidbad, inpgood, inpbad } = data[i];
+        if ((i % 2) === 1) {
+          listGridRow.classList.add('odd');
+        }
+        const {
+          lcpgood, lcpbad, clsgood, clsbad, fidgood, fidbad, inpgood, inpbad,
+        } = data[i];
 
         const lcpOkay = 100 - (lcpgood + lcpbad);
         const clsOkay = 100 - (clsgood + clsbad);
         const fidOkay = 100 - (fidgood + fidbad);
         const inpOkay = 100 - (inpgood + inpbad);
-        const avgOkay = (lcpOkay + clsOkay + fidOkay + inpOkay)/4;
-        const avgGood = (lcpgood + clsgood + fidgood + inpgood)/4;
-        const avgBad =  (lcpbad + clsbad + fidbad + inpbad)/4;
-        for(let j = 0; j < 7; j++){
-          let listGridColumn = document.createElement('div');
+        const avgOkay = Math.round((lcpOkay + clsOkay + fidOkay + inpOkay) / 4);
+        const avgGood = Math.round((lcpgood + clsgood + fidgood + inpgood) / 4);
+        const avgBad = Math.round((lcpbad + clsbad + fidbad + inpbad) / 4);
+        for (let j = 0; j < 7; j += 1) {
+          const listGridColumn = document.createElement('div');
           listGridColumn.classList.add('grid', 'list', 'col', cols[j]);
-          if(cols[j] === 'usrexp'){
-            let badPerc = document.createElement('div')
-            let goodPerc = document.createElement('div');
-            let okayPerc = document.createElement('div');
-            badPerc.classList.add('grid', 'list', 'col', cols[j], 'badbar')
-            goodPerc.classList.add('grid', 'list', 'col', cols[j], 'goodbar')
-            okayPerc.classList.add('grid', 'list', 'col', cols[j], 'okaybar')
-            let badPercentage = avgBad+'%';
-            let goodPercentage = avgGood+'%';
-            let okayPercentage = avgOkay+'%';
+          if (cols[j] === 'usrexp') {
+            const badPerc = document.createElement('div');
+            const goodPerc = document.createElement('div');
+            const okayPerc = document.createElement('div');
+            badPerc.classList.add('grid', 'list', 'col', cols[j], 'badbar');
+            goodPerc.classList.add('grid', 'list', 'col', cols[j], 'goodbar');
+            okayPerc.classList.add('grid', 'list', 'col', cols[j], 'okaybar');
+            const badPercentage = `${avgBad}%`;
+            const goodPercentage = `${avgGood}%`;
+            const okayPercentage = `${avgOkay}%`;
             badPerc.textContent = badPercentage;
             goodPerc.textContent = goodPercentage;
             okayPerc.textContent = okayPercentage;
             badPerc.style.width = badPercentage;
             goodPerc.style.width = goodPercentage;
             okayPerc.style.width = okayPercentage;
+            if (avgBad < 10) badPerc.style.color = 'red';
+            if (avgGood < 10) goodPerc.style.color = 'green';
+            if (avgOkay < 10) okayPerc.style.color = 'orange';
             listGridColumn.appendChild(goodPerc);
             listGridColumn.appendChild(okayPerc);
             listGridColumn.appendChild(badPerc);
-          }else{
+          } else {
             let txtContent;
-            if(cols[j] === 'avglcp'){
-              txtContent = data[i][cols[j]]/1000.00;
+            if (cols[j] === 'avglcp') {
+              txtContent = data[i][cols[j]] / 1000.00;
+            } else if (cols[j] === 'url') {
+              listGridColumn.innerHTML = `<a href='${data[i][cols[j]]}' target="_blank">${data[i][cols[j]].replace(/^https?:\/\/[^/]+/i, '')}</a>`;
+            } else {
+              txtContent = data[i][cols[j]];
             }
-            else{
-              if(cols[j] === 'url'){
-                listGridColumn.innerHTML = `<a href='${data[i][cols[j]]}' target="_blank">${data[i][cols[j]].replace(/^https?\:\/\/www./i, "")}</a>`;
-              }
-              else{
-                txtContent = data[i][cols[j]];
-              }
-            }
-            if(j >= 3){
-              if(data[i][cols[j]] <= ranges[cols[j]][0]){
+            if (j >= 3) {
+              if (data[i][cols[j]] <= ranges[cols[j]][0]) {
                 listGridColumn.classList.toggle('pass');
-              }
-              else if(data[i][cols[j]] > ranges[cols[j]][0] && data[i][cols[j]] < ranges[cols[j]][1]){
+              } else if (
+                data[i][cols[j]] > ranges[cols[j]][0] && data[i][cols[j]] < ranges[cols[j]][1]
+              ) {
                 listGridColumn.classList.toggle('okay');
-              }
-              else{
+              } else {
                 listGridColumn.classList.toggle('fail');
               }
             }
-            if(txtContent){
-              if(j >= 3){
-                listGridColumn.textContent = txtContent + `${metrics[j - 3]}`;
-              }
-              else{
-                listGridColumn.textContent = txtContent
+            if (txtContent) {
+              if (j >= 3) {
+                listGridColumn.textContent = `${txtContent}${metrics[j - 3]}`;
+              } else {
+                listGridColumn.textContent = txtContent;
               }
             }
           }

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -1,15 +1,11 @@
 /* eslint-disable import/no-cycle */
-import { sampleRUM } from './lib-franklin.js';
+import { sampleRUM, getMetadata } from './lib-franklin.js';
 
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
 
 // load echarts library unless the page metadata says otherwise
-let loadecharts = true;
-if (document.querySelector('meta[name="echarts"]') && document.querySelector('meta[name="echarts"]').content === 'false') {
-  loadecharts = false;
-}
-if (loadecharts) {
+if (getMetadata('echarts') !== 'false') {
   const echartScript = document.createElement('script');
   echartScript.type = 'text/javascript';
   echartScript.src = 'https://cdn.jsdelivr.net/npm/echarts@5.4.2/dist/echarts.min.js';

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -192,8 +192,8 @@ export async function queryRequest(cfg, fullEndpoint) {
             window.dashboard = {};
           }
           window.dashboard[endpoint] = data;
-          let main = document.querySelector('main');
-          let loader = main.querySelector('.loader');
+          const main = document.querySelector('main');
+          const loader = main.querySelector('.loader');
           loader.remove();
         })
         .catch((err) => {
@@ -263,8 +263,8 @@ async function loadLazy(doc) {
   sampleRUM.observe(main.querySelectorAll('div[data-block-name]'));
   sampleRUM.observe(main.querySelectorAll('picture > img'));
 
-  let html = document.querySelector('html');
-  html.classList.add('spectrum', 'spectrum--dark')
+  const html = document.querySelector('html');
+  html.classList.add('spectrum', 'spectrum--dark');
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -192,9 +192,6 @@ export async function queryRequest(cfg, fullEndpoint) {
             window.dashboard = {};
           }
           window.dashboard[endpoint] = data;
-          const main = document.querySelector('main');
-          const loader = main.querySelector('.loader');
-          loader.remove();
         })
         .catch((err) => {
         // eslint-disable-next-line no-console


### PR DESCRIPTION
Various lint, style, UI updates for the rum-dashboard datalist page.  The sample gdrive page used for development will eventually move from `/screens/experimental/datalist-style` to `/publish/datalist`.  Styling is not final but wanted to get a PR in quickly to merge progress into the datalist branch.

Fix #28

Test URLs:
- Before: https://datalist--franklin-dashboard--adobe.hlx.live/screens/experimental/datalist-style?domainkey=8e884fda-f644-4708-b583-a4b0715068cd&interval=30&offset=1&limit=30&url=www.hlx.live
- After: https://datalist-style--franklin-dashboard--adobe.hlx.live/screens/experimental/datalist-style?domainkey=8e884fda-f644-4708-b583-a4b0715068cd&interval=30&offset=1&limit=30&url=www.hlx.live
