### PR TITLE
report styling to align with list styling

### DIFF
--- a/blocks/report/report.css
+++ b/blocks/report/report.css
@@ -1,12 +1,7 @@
 div.grid.list.container {
-    display: grid;
-    position: sticky;
-    top: 0;
-    grid-gap: 1em;
-    background-color: var(--overlay-background-color);
-    height: 100vh;
-    width: 100%;
-    overflow: scroll;
+  display: grid;
+  grid-gap: 0.2em;
+  width: 100%;
 }
 
 .flex { 
@@ -25,7 +20,7 @@ div.grid.list.container {
 div.grid.list.row {
     display: grid;
     height: 100%;
-    grid-template-columns: 4fr 4fr 2fr 2fr 3fr 2fr;
+    grid-template-columns: 4fr 4fr 1fr 1fr 2fr 1fr;
     grid-gap: 10px;
     align-items: center;
     justify-items: center;
@@ -37,10 +32,12 @@ div.grid.list.row:not(.heading){
 }
 
 div.grid.list.row.heading {
-    height: fit-content;
-    position: sticky;
-    top: 0;
-    background-color:grey;
+  font-weight: bold;
+  background-color: var(--highlight-background-color);
+}
+
+div.grid.list.row.odd {
+  background-color: var(--overlay-background-color);
 }
 
 div.grid.list.col {
@@ -48,12 +45,12 @@ div.grid.list.col {
     width: 100%;
     text-overflow: ellipsis;
     overflow: hidden;
-    font-size: medium;
+    font-size: var(--body-font-size-xs);
     justify-content: center;
     align-items: center;
 }
 
-div.grid.list.col.source, div.grid.list.col.topurl {
+div.grid.list.col.source, div.grid.list.col.source div.inner, div.grid.list.col.topurl {
     align-items: start;
     justify-content: start;
     text-overflow: ellipsis;
@@ -72,55 +69,55 @@ div.grid.list.col.source, div.grid.list.col.topurl {
 }
 
 .loader {
-    /* align-items: center; */
-    margin: auto;
+  margin: auto;
+  width: calc(100px - 24px);
+  height: 50vh;
+  position: relative;
+  animation: flippx 2s infinite linear;
+}
 
-    /* justify-content: center; */
+.loader::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background:red;
+  transform-origin: -24px 50%;
+  animation: spin 1s infinite linear;
+}
 
-    /* position: absolute; */
-    width: calc(100px - 24px);
-    height: 50vh;
-    position: relative;
-    animation: flippx 2s infinite linear;
-  }
-
-  .loader::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    margin: auto;
-    width: 20px;
-    height: 20px;
-    border-radius: 50%;
-    background:red;
-    transform-origin: -24px 50%;
-    animation: spin 1s infinite linear;
-  }
-
-  .loader::after {
-    content: "";
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50% , -50%);
-    background: blue;
-    width: 48px;
-    height: 48px;
-    border-radius: 50%;
-  }
+.loader::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50% , -50%);
+  background: blue;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+}
   
-  @keyframes flippx {
-    0%, 49% {
-      transform: scaleX(1);
-    }
-
-    50%, 100% {
-      transform: scaleX(-1);
-    }
+@keyframes flippx {
+  0%, 49% {
+    transform: scaleX(1);
   }
 
-  @keyframes spin {
-    100% {
-      transform: rotate(360deg);
-    }
+  50%, 100% {
+    transform: scaleX(-1);
   }
+}
+
+@keyframes spin {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+div.section.report-container p {
+    font-size: var(--body-font-size-s);
+    margin-top: 0;
+}

--- a/blocks/report/report.js
+++ b/blocks/report/report.js
@@ -21,7 +21,10 @@ export default function decorate(block) {
     if (Object.hasOwn(window, 'gettingQueryInfo') && window.gettingQueryInfo === true) {
       window.setTimeout(getQuery, 1);
     } else if (Object.hasOwn(window, 'gettingQueryInfo') && window.gettingQueryInfo === false) {
-      queryRequest(cfg, getUrlBase(endpoint), {checkpoint: '404'});
+      setTimeout(() => {
+        queryRequest(cfg, getUrlBase(endpoint), { checkpoint: '404' });
+      }, 3000);
+
       const loaderSpan = document.createElement('div');
       loaderSpan.className = 'loader';
       block.append(loaderSpan);
@@ -50,7 +53,21 @@ export default function decorate(block) {
       listGridHeadingRow.classList.add('grid', 'list', 'row', 'heading');
       for (let j = 0; j < 6; j += 1) {
         const listGridHeadings = document.createElement('div');
-        listGridHeadings.textContent = cols[j];
+        if (cols[j] === 'topurl') {
+          listGridHeadings.textContent = '404 path';
+        } else if (cols[j] === 'source') {
+          listGridHeadings.textContent = 'Referer';
+        } else if (cols[j] === 'actions') {
+          listGridHeadings.textContent = 'actions?';
+        } else if (cols[j] === 'views') {
+          listGridHeadings.textContent = 'views?';
+        } else if (cols[j] === 'actions_per_view') {
+          listGridHeadings.textContent = 'actions_per_view?';
+        } else if (cols[j] === 'pages') {
+          listGridHeadings.textContent = 'pages?';
+        } else {
+          listGridHeadings.textContent = cols[j];
+        }
         listGridHeadings.classList.add('grid', 'list', 'col', 'heading');
         listGridHeadingRow.appendChild(listGridHeadings);
       }
@@ -79,15 +96,19 @@ export default function decorate(block) {
       }
 
       const entries = Object.entries(map404);
+      let counter = 0;
       entries.forEach(([key, val]) => {
         const listGridRow = document.createElement('div');
         listGridRow.classList.add('grid', 'list', 'row');
+        if ((counter % 2) === 1) {
+          listGridRow.classList.add('odd');
+        }
 
         const listGridColumn = document.createElement('div');
         listGridColumn.classList.add('grid', 'list', 'col', 'topurl');
         const link = document.createElement('a');
         link.href = key;
-        link.textContent = key;
+        link.textContent = key.replace(/^https?:\/\/[^/]+/i, '');
         listGridColumn.append(link);
         listGridRow.append(listGridColumn);
 
@@ -103,6 +124,7 @@ export default function decorate(block) {
             const content = val[k][keys[l]];
             const innerDiv = document.createElement('div');
             innerDiv.classList.add('grid', 'list', 'col', keys[l], 'inner');
+            // TODO the source field never shows a link, possible bug
             if (keys[l] === 'source' && val[k][keys[l]] !== 'empty') {
               const srcLink = document.createElement('a');
               srcLink.href = content;
@@ -118,6 +140,7 @@ export default function decorate(block) {
           listGridRow.append(gridElementArray[i]);
         }
         listGridContainer.append(listGridRow);
+        counter += 1;
       });
       block.append(listGridContainer);
     }


### PR DESCRIPTION
Align 404 report styles with datalist styles.  Regarding the test URLs below, I recommend manual review changing the domainkey and url params.

Test URLs:
- Before: https://report404--franklin-dashboard--adobe.hlx.page/publish/404report?domainkey=8e884fda-f644-4708-b583-a4b0715068cd&interval=30&offset=1&limit=30&url=www.hlx.live
- After: https://report404-style--franklin-dashboard--adobe.hlx.page/publish/404report?domainkey=8e884fda-f644-4708-b583-a4b0715068cd&interval=30&offset=1&limit=30&url=www.hlx.live
