### PR TITLE
styles, externalize loader, handle no results

### DIFF
--- a/blocks/list/list.css
+++ b/blocks/list/list.css
@@ -122,55 +122,6 @@ div.grid.list.col.pageviews {
     background-color: orange;
 }
 
-.loader {
-    margin: auto;
-    width: calc(100px - 24px);
-    height: 50vh;
-    position: relative;
-    animation: flippx 2s infinite linear;
-}
-
-.loader::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    margin: auto;
-    width: 20px;
-    height: 20px;
-    border-radius: 50%;
-    background:red;
-    transform-origin: -24px 50%;
-    animation: spin 1s infinite linear;
-}
-
-.loader::after {
-    content: "";
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50% , -50%);
-    background: blue;
-    width: 48px;
-    height: 48px;
-    border-radius: 50%;
-}
-  
-@keyframes flippx {
-    0%, 49% {
-      transform: scaleX(1);
-    }
-
-    50%, 100% {
-      transform: scaleX(-1);
-    }
-}
-
-@keyframes spin {
-    100% {
-      transform: rotate(360deg);
-    }
-}
-
 div.section.list-container p {
     font-size: var(--body-font-size-s);
     margin-top: 0;

--- a/blocks/list/list.js
+++ b/blocks/list/list.js
@@ -1,5 +1,6 @@
 import { readBlockConfig } from '../../scripts/lib-franklin.js';
 import { getQueryInfo, queryRequest, getUrlBase } from '../../scripts/scripts.js';
+import { drawLoader, hideLoader } from '../../scripts/loader.js';
 
 export default function decorate(block) {
   let cfg = readBlockConfig(block);
@@ -25,9 +26,7 @@ export default function decorate(block) {
         queryRequest(cfg, getUrlBase(endpoint));
       }, 3000);
 
-      const loaderSpan = document.createElement('div');
-      loaderSpan.className = 'loader';
-      block.append(loaderSpan);
+      drawLoader(block);
     }
   };
 
@@ -37,9 +36,7 @@ export default function decorate(block) {
     } else if (Object.hasOwn(window, flag) && window[flag] === false) {
       // query complete, hide loading graphic
       const { data } = window.dashboard[endpoint].results;
-      const main = document.querySelector('main');
-      const loader = main.querySelector('.loader');
-      loader.remove();
+      hideLoader(block);
 
       const listGridContainer = document.createElement('div');
       listGridContainer.classList.add('grid', 'list', 'container');
@@ -78,6 +75,8 @@ export default function decorate(block) {
         listGridHeadingRow.appendChild(listGridHeadings);
       }
       listGridContainer.appendChild(listGridHeadingRow);
+
+      let counter = 0;
 
       for (let i = 0; i < data.length; i += 1) {
         const listGridRow = document.createElement('div');
@@ -154,8 +153,21 @@ export default function decorate(block) {
           listGridRow.append(listGridColumn);
         }
         listGridContainer.append(listGridRow);
+
+        counter = i;
       }
       block.append(listGridContainer);
+
+      if (counter === 0) {
+        const noresults = document.createElement('p');
+        const params = new URLSearchParams(window.location.search);
+        if (params.has('domainkey') && params.has('url')) {
+          noresults.textContent = 'No results found.';
+        } else {
+          noresults.innerHTML = '<i>domainkey</i> and <i>url</i> (hostname) are required.  Please provide <a href="/">here</a>.';
+        }
+        block.append(noresults);
+      }
     }
   };
   getQuery();

--- a/blocks/report/report.css
+++ b/blocks/report/report.css
@@ -75,55 +75,6 @@ div.grid.list.col.source, div.grid.list.col.source div.inner, div.grid.list.col.
     border-bottom-style: solid;
 }
 
-.loader {
-  margin: auto;
-  width: calc(100px - 24px);
-  height: 50vh;
-  position: relative;
-  animation: flippx 2s infinite linear;
-}
-
-.loader::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  margin: auto;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background:red;
-  transform-origin: -24px 50%;
-  animation: spin 1s infinite linear;
-}
-
-.loader::after {
-  content: "";
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50% , -50%);
-  background: blue;
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-}
-  
-@keyframes flippx {
-  0%, 49% {
-    transform: scaleX(1);
-  }
-
-  50%, 100% {
-    transform: scaleX(-1);
-  }
-}
-
-@keyframes spin {
-  100% {
-    transform: rotate(360deg);
-  }
-}
-
 div.section.report-container p {
     font-size: var(--body-font-size-s);
     margin-top: 0;

--- a/blocks/report/report.js
+++ b/blocks/report/report.js
@@ -1,5 +1,6 @@
 import { readBlockConfig } from '../../scripts/lib-franklin.js';
 import { getQueryInfo, queryRequest, getUrlBase } from '../../scripts/scripts.js';
+import { drawLoader, hideLoader } from '../../scripts/loader.js';
 
 export default function decorate(block) {
   let cfg = readBlockConfig(block);
@@ -25,9 +26,7 @@ export default function decorate(block) {
         queryRequest(cfg, getUrlBase(endpoint), { checkpoint: '404' });
       }, 3000);
 
-      const loaderSpan = document.createElement('div');
-      loaderSpan.className = 'loader';
-      block.append(loaderSpan);
+      drawLoader(block);
     }
   };
 
@@ -37,12 +36,7 @@ export default function decorate(block) {
     } else if (Object.hasOwn(window, flag) && window[flag] === false) {
       // query complete, hide loading graphic
       const { data } = window.dashboard[endpoint].results;
-      document.querySelectorAll('div.loading').forEach((loading) => {
-        loading.style.display = 'none';
-      });
-      const main = document.querySelector('main');
-      const loader = main.querySelector('.loader');
-      loader.remove();
+      hideLoader(block);
 
       const listGridContainer = document.createElement('div');
       listGridContainer.classList.add('grid', 'list', 'container');
@@ -115,7 +109,6 @@ export default function decorate(block) {
             const content = val[k][keys[l]];
             const innerDiv = document.createElement('div');
             innerDiv.classList.add('grid', 'list', 'col', keys[l], 'inner');
-            // TODO the source field never shows a link, possible bug
             if (keys[l] === 'sourceNew' && val[k][keys[l]] !== 'empty') {
               const srcLink = document.createElement('a');
               srcLink.href = content;
@@ -134,6 +127,17 @@ export default function decorate(block) {
         counter += 1;
       });
       block.append(listGridContainer);
+
+      if (counter === 0) {
+        const noresults = document.createElement('p');
+        const params = new URLSearchParams(window.location.search);
+        if (params.has('domainkey') && params.has('url')) {
+          noresults.textContent = 'No results found.';
+        } else {
+          noresults.innerHTML = '<i>domainkey</i> and <i>url</i> (hostname) are required.  Please provide <a href="/">here</a>.';
+        }
+        block.append(noresults);
+      }
     }
   };
   getQuery();

--- a/scripts/loader.js
+++ b/scripts/loader.js
@@ -1,0 +1,18 @@
+/**
+ * draw a loading graphic in the specified DOM element
+ * @param {Element} domObj The target DOM element
+ */
+export function drawLoader(domObj) {
+  const loaderSpan = document.createElement('div');
+  loaderSpan.className = 'loader';
+  domObj.append(loaderSpan);
+}
+
+/**
+ * hide the loading graphic in the specified DOM element
+ * @param {Element} domObj The target DOM element
+ */
+export function hideLoader(domObj) {
+  const loader = domObj.querySelector('.loader');
+  loader.remove();
+}

--- a/scripts/loading.js
+++ b/scripts/loading.js
@@ -1,3 +1,6 @@
+// NOTE This is a legacy loader and should not be used anymore.  Use loader.js instead.
+// TODO Delete this file once all blocks using it are updated.
+
 /**
  * draw a loading graphic in the specified DOM element
  * @param {Element} domObj The target DOM element

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -96,7 +96,6 @@ export function getEndpointParams(endpoint) {
  * @param {*} main
  */
 export async function queryRequest(cfg, fullEndpoint, qps = {}) {
-  // let's make a loader
   let offset;
   let interval;
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -76,7 +76,7 @@ h4, h5, h6 {
   font-family: var(--heading-font-family);
   font-weight: 600;
   line-height: 1.25;
-  margin-top: 1em;
+  margin-top: .25em;
   margin-bottom: .5em;
   scroll-margin: calc(var(--nav-height) + 1em);
 }
@@ -309,11 +309,51 @@ footer {
   width: 100%;
 }
 
-/*
-.section.lists-container > .lists-wrapper {
-  grid-column: 1 / 2;
-  grid-row: 2 / 4;
-  display: flex;
-  flex-wrap: wrap;
+.loader {
+  margin: auto;
+  width: calc(100px - 24px);
+  height: 50vh;
+  position: relative;
+  animation: flippx 2s infinite linear;
 }
-*/
+
+.loader::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background:red;
+  transform-origin: -24px 50%;
+  animation: spin 1s infinite linear;
+}
+
+.loader::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50% , -50%);
+  background: blue;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+}
+
+@keyframes flippx {
+  0%, 49% {
+    transform: scaleX(1);
+  }
+
+  50%, 100% {
+    transform: scaleX(-1);
+  }
+}
+
+@keyframes spin {
+  100% {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
Minor style updates, moved loader CSS and javascript out of each block, added logic to display message when no results are found - either due to legitimately no results or empty domainkey and url params (which happens when using standard Franklin preview/publish functionality).

Test URLs:
- Before: https://main--franklin-dashboard--adobe.hlx.live/views/rum-dashboard?domainkey=8e884fda-f644-4708-b583-a4b0715068cd&url=www.hlx.live
- After: https://dash-styles--franklin-dashboard--adobe.hlx.live/views/rum-dashboard?domainkey=8e884fda-f644-4708-b583-a4b0715068cd&url=www.hlx.live
