### PR TITLE
fix(https): remove https prefix as it interferes

### DIFF
--- a/blocks/filter/filter.css
+++ b/blocks/filter/filter.css
@@ -21,7 +21,7 @@
 .filter div {
     flex-grow: 1;
     flex-shrink: 1;
-    width: 150px;
+    width: 300px;
     margin: auto;
 }
 
@@ -42,7 +42,7 @@
 }
 
 .filter input {
-    width: fit-content;
+    width: 300px;
     font-size: var(--body-font-size-xs);
 }
 

--- a/blocks/filter/filter.js
+++ b/blocks/filter/filter.js
@@ -149,7 +149,7 @@ function drawFilter(block, cfg) {
   const ownerrepo = params.get('owner_repo') || '';
   const domainkey = params.get('domainkey');
   let interval = params.get('interval') || '30';
-  let offset = params.get('offset') || '1';
+  let offset = params.get('offset') || '0';
   const startdate = params.get('startdate') || '';
   const enddate = params.get('enddate') || '';
   const limit = params.get('limit') || '10';

--- a/blocks/filter/filter.js
+++ b/blocks/filter/filter.js
@@ -334,6 +334,7 @@ export default function decorate(block) {
   });
   block.querySelector('#url').addEventListener('blur', () => {
     focus('url', false);
+    block.querySelector('#url').value = block.querySelector('#url').value.replace(/^http(s)*:\/\//, '');
   });
   block.querySelector('#owner_repo').addEventListener('blur', () => {
     focus('owner_repo', false);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -180,6 +180,11 @@ export async function queryRequest(endpoint, endpointHost, qps = {}) {
     params.set('offset', '0');
   }
 
+  // remove http or https prefix in url param if it exists
+  if (params.has('url')) {
+    params.set('url', params.get('url').replace(/^http(s)*:\/\//, ''));
+  }
+
   const limit = params.get('limit') || '30';
   params.set('limit', limit);
   Object.entries(qps).forEach(([k, v]) => {


### PR DESCRIPTION
Add tolerance for http:// or https:// prefix in the `url` param by stripping it before calling the query endpoint.  Remove the prefix when entered via UI.  Increase size of URL param in filter block for readability.

Fix #43

Test URLs:
- Before: https://main--franklin-dashboard--adobe.hlx.live/views/rum-dashboard?domainkey=8e884fda-f644-4708-b583-a4b0715068cd&url=https://www.hlx.live
- After: https://removehttps--franklin-dashboard--adobe.hlx.live/views/rum-dashboard?domainkey=8e884fda-f644-4708-b583-a4b0715068cd&url=https://www.hlx.live
