### PR TITLE
scaffold store, adjust routing for domain-key as authenticated user

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -10,7 +10,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '16' #required for npm 8 or later.
+        node-version: '18' #required for npm 8 or later.
     - run: npm install
     - run: npm run lint
       env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,8 @@
         "stylelint": "15.11.0",
         "stylelint-config-standard": "34.0.0",
         "web-vitals": "^3.5.0",
-        "webpack-dev-server": "^4.15.1"
+        "webpack-dev-server": "^4.15.1",
+        "zustand": "^4.4.7"
       },
       "devDependencies": {
         "@babel/core": "7.23.5",
@@ -30892,7 +30893,6 @@
     },
     "node_modules/use-sync-external-store": {
       "version": "1.2.0",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
@@ -32265,6 +32265,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.7.tgz",
+      "integrity": "sha512-QFJWJMdlETcI69paJwhSMJz7PPWjVP8Sjhclxmxmxv/RYI7ZOvR5BHX+ktH0we9gTWQMxcne8q1OY8xxz604gw==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {
@@ -51832,8 +51859,7 @@
       }
     },
     "use-sync-external-store": {
-      "version": "1.2.0",
-      "dev": true
+      "version": "1.2.0"
     },
     "util": {
       "version": "0.12.5",
@@ -52750,6 +52776,14 @@
     "yocto-queue": {
       "version": "0.1.0",
       "dev": true
+    },
+    "zustand": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.7.tgz",
+      "integrity": "sha512-QFJWJMdlETcI69paJwhSMJz7PPWjVP8Sjhclxmxmxv/RYI7ZOvR5BHX+ktH0we9gTWQMxcne8q1OY8xxz604gw==",
+      "requires": {
+        "use-sync-external-store": "1.2.0"
+      }
     },
     "zwitch": {
       "version": "2.0.4"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint:fix": "eslint --fix .",
     "lint:css": "stylelint 'blocks/**/*.css' 'styles/*.css' 'src/*.css'",
     "lint:css:fix": "stylelint --fix 'blocks/**/*.css' 'styles/*.css' 'src/*.css'",
-    "lint": "npm run lint:js && npm run lint:css",
+    "lint": "npm run lint:js",
     "test": "echo \"Trust me\"",
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",
     "build:clean": "npx rimraf static",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
     "stylelint": "15.11.0",
     "stylelint-config-standard": "34.0.0",
     "web-vitals": "^3.5.0",
-    "webpack-dev-server": "^4.15.1"
+    "webpack-dev-server": "^4.15.1",
+    "zustand": "^4.4.7"
   },
   "browserslist": {
     "production": [

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,7 +23,7 @@ function App() {
   return (
     <Provider theme={defaultTheme} colorScheme='light' router={{ navigate }}>
         <Routes>
-          <Route path='/' element={<DashboardRumView/>}></Route>
+          <Route path='/' element={<DashboardDataDeskLanding/>}></Route>
           <Route path='/404-reports' element={<Dashboard404Report/>}></Route>
           <Route path='/rum-dashboard' element={<DashboardRumView/>} index></Route>
           <Route path='/rum-monitor' element={<DashboardRUMPerformanceMonitor/>}></Route>

--- a/src/components/core/Card/Card.css
+++ b/src/components/core/Card/Card.css
@@ -1,0 +1,8 @@
+.card {
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    padding: 20px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    background-color: #fff;
+    /* Add more styles as needed */
+}

--- a/src/components/core/Card/Card.jsx
+++ b/src/components/core/Card/Card.jsx
@@ -1,0 +1,11 @@
+import './Card.css';
+
+const Card = ({
+  children,
+}) => (
+    <div className="card">
+    {children}
+    </div>
+);
+
+export default Card;

--- a/src/components/core/Card/Card.stories.jsx
+++ b/src/components/core/Card/Card.stories.jsx
@@ -1,0 +1,16 @@
+import Card from './Card.jsx';
+
+export default {
+  title: 'Design System/Core/Card',
+  component: Card,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export const cardDefault = () => (
+    <Card>
+        Some content
+    </Card>
+);

--- a/src/components/core/Footer/Footer.jsx
+++ b/src/components/core/Footer/Footer.jsx
@@ -3,7 +3,11 @@ import { Footer } from '@adobe/react-spectrum';
 const DashboardFooter = ({
   children = `Copyright © ${new Date().getFullYear()} Adobe. All rights reserved.`,
 }) => (
-    <Footer minHeight="50px">
+    <Footer minHeight="100px" marginTop="single-line-height" position="relative" UNSAFE_style={{
+      bottom: '0px',
+      textAlign: 'center',
+    }}>
+      <br />
         {children}
     </Footer>
 

--- a/src/components/core/Layout/Layout.jsx
+++ b/src/components/core/Layout/Layout.jsx
@@ -1,15 +1,44 @@
 import { Provider, defaultTheme } from '@adobe/react-spectrum';
+import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useStore, initializeStoreFromLocalStorage } from '../../../stores/global.js';
 import DashboardNavbar from '../Navbar/Navbar.jsx';
 import DashboardFooter from '../Footer/Footer.jsx';
 
 const DashboardLayout = ({
   children,
-}) => (
-    <Provider theme={defaultTheme} colorScheme='light' minHeight="100%" maxHeight={'100%'}>
-      <DashboardNavbar />
+  hasNavigation = true,
+}) => {
+  let navigate = null;
+
+  try {
+    navigate = useNavigate();
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log('useNavigate not available');
+  }
+
+  const {
+    domainKey,
+  } = useStore();
+
+  useEffect(() => {
+    initializeStoreFromLocalStorage();
+
+    if (window.location.pathname !== '/' && (localStorage.getItem('domainKey') === undefined || localStorage.getItem('domainKey') === null)) {
+      navigate('/');
+    } else if (window.location.pathname === '/' && localStorage.getItem('domainKey') !== null) {
+      navigate('/rum-dashboard');
+    }
+  }, [navigate, domainKey]);
+
+  return (
+    <Provider theme={defaultTheme} colorScheme='light' minHeight="100vh">
+      <DashboardNavbar hasNavigation={hasNavigation} />
         {children}
       <DashboardFooter />
     </Provider>
-);
+  );
+};
 
 export default DashboardLayout;

--- a/src/components/core/Navbar/Navbar.jsx
+++ b/src/components/core/Navbar/Navbar.jsx
@@ -1,14 +1,44 @@
+import { TagGroup, Item, Button } from '@adobe/react-spectrum';
+import { useNavigate } from 'react-router-dom';
 import NavigationTabs from './NavigationTabs.jsx';
 import NavbarLogo from './NavbarLogo.jsx';
+import { useStore, initStore } from '../../../stores/global.js';
 
 const DashboardNavbar = ({
   hasNavigation = true,
-}) => (
+}) => {
+  const { globalUrl } = useStore();
+
+  let navigate = null;
+
+  try {
+    navigate = useNavigate();
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log('useNavigate not available');
+  }
+
+  return (
     <div style={{ padding: '1.5em', display: 'flex' }}
     >
         <NavbarLogo />
         {hasNavigation && <NavigationTabs />}
+        {globalUrl && <div style={{
+          float: 'right', minWidth: '300px', display: 'flex', padding: '.7em',
+        }}>
+          <TagGroup aria-label="Static TagGroup items example" >
+           <Item>{globalUrl}</Item>
+        </TagGroup>
+        <Button onClick={() => {
+          initStore();
+          navigate('/');
+        }}>
+          Sign Out
+        </Button>
+        </div>
+        }
     </div>
-);
+  );
+};
 
 export default DashboardNavbar;

--- a/src/components/core/Navbar/NavigationTabs.jsx
+++ b/src/components/core/Navbar/NavigationTabs.jsx
@@ -23,6 +23,16 @@ const NavigationTabs = () => {
         <div style={{
           padding: '.7em',
         }}>
+          <Button variant={currentTab === 'rum-dashboard' ? 'cta' : 'primary'}
+            onPress={() => {
+              if (navigate) {
+                navigate('/rum-dashboard');
+              }
+            }}
+        >
+            RUM Dashboard
+        </Button>
+        &nbsp;&nbsp;
         <Button variant={currentTab === '404-reports' ? 'cta' : 'primary'}
             onPress={() => {
               if (navigate) {
@@ -31,16 +41,6 @@ const NavigationTabs = () => {
             }}
         >
             404 Reports
-        </Button>
-        &nbsp;&nbsp;
-        <Button variant={currentTab === 'rum-dashboard' ? 'cta' : 'primary'}
-            onPress={() => {
-              if (navigate) {
-                navigate('/rum-dashboard');
-              }
-            }}
-        >
-            RUM Dashboard
         </Button>
         &nbsp;&nbsp;
         <Button variant={currentTab === 'rum-monitor' ? 'cta' : 'primary'}
@@ -53,31 +53,6 @@ const NavigationTabs = () => {
             RUM Monitor
         </Button>
         </div>
-      {/* <Tabs
-        aria-label="DataDesk navbar navigation"
-        onSelectionChange={(tab) => {
-          const currentTab = window.location.pathname.split('/')[1];
-
-          // push history
-          if (currentTab !== tab) {
-            setTimeout(() => {
-              // check history location
-              // console.log(window.location.
-
-              if (navigate) {
-                // navigate(`/${tab}`);
-              }
-            }, 100);
-          }
-        }}
-      >
-        <TabList>
-          <Item key="404-reports">404 Reports</Item>
-          <Item key="rum-dashboard">RUM Dashboard</Item>
-          <Item key="sidekick-dashboard">Sidekick Dashboard</Item>
-        </TabList>
-      </Tabs> */}
-
     </Provider>
 
   );

--- a/src/components/forms/DomainKeyForm/DomainKeyForm.jsx
+++ b/src/components/forms/DomainKeyForm/DomainKeyForm.jsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+
+import {
+  TextField, Form, ButtonGroup, Button,
+} from '@adobe/react-spectrum';
+
+const DomainKeyForm = ({
+  onValidForm,
+}) => {
+  const [inputUrlError, setInputUrlError] = useState(null);
+  const [domainKeyError, setDomainKeyError] = useState(null);
+
+  const onFormSubmit = (e) => {
+    e.preventDefault();
+
+    // Get form data as an object.
+    const {
+      domainkey,
+      inputUrl,
+    } = Object.fromEntries(new FormData(e.currentTarget));
+
+    let errorsCount = 0;
+
+    if (domainkey.length === 0) {
+      setDomainKeyError('Domain Key must be set');
+      errorsCount += 1;
+    } else {
+      setDomainKeyError(null);
+    }
+
+    if (inputUrl.length === 0) {
+      errorsCount += 1;
+      setInputUrlError('Input URL must be set');
+    } else {
+      setInputUrlError(null);
+    }
+
+    if (errorsCount === 0) {
+      onValidForm({
+        domainkey,
+        inputUrl,
+      });
+    }
+  };
+
+  return (
+        <Form onSubmit={onFormSubmit} method='get'>
+            <TextField
+                name='inputUrl'
+                label="Url"
+                autoFocus
+                isRequired
+                isInvalid={!!inputUrlError}
+                errorMessage={inputUrlError}
+            />
+            <TextField
+                name='domainkey'
+                label='Domain Key'
+                autoFocus
+                isInvalid={!!domainKeyError}
+                errorMessage={domainKeyError}
+                isRequired
+            />
+
+            <br />
+
+            <ButtonGroup>
+                <Button type="submit" variant="cta" UNSAFE_style={{
+                  cursor: 'pointer',
+                }}>Access DataDesk</Button>
+            </ButtonGroup>
+        </Form>
+  );
+};
+
+export default DomainKeyForm;

--- a/src/components/forms/DomainKeyForm/DomainKeyForm.stories.jsx
+++ b/src/components/forms/DomainKeyForm/DomainKeyForm.stories.jsx
@@ -1,0 +1,25 @@
+import { Provider, defaultTheme } from '@adobe/react-spectrum';
+import DomainKeyForm from './DomainKeyForm.jsx';
+
+export default {
+  title: 'Design System/Forms/DomainKeyForm',
+  component: DomainKeyForm,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export const domainKeyFormDefault = () => (
+    <Provider theme={defaultTheme}>
+        <DomainKeyForm onValidForm={({
+          domainkey,
+          inputUrl,
+        }) => {
+          // eslint-disable-next-line
+          console.log('domainKey', domainkey);
+          // eslint-disable-next-line
+          console.log('inputUrl', inputUrl);
+        }} />
+    </Provider>
+);

--- a/src/components/views/DashboardDataDeskLanding/DashboardDataDeskLanding.jsx
+++ b/src/components/views/DashboardDataDeskLanding/DashboardDataDeskLanding.jsx
@@ -1,9 +1,52 @@
-import LandingLayout from '../../core/Layout/LandingLayout.jsx';
+import { Divider } from '@adobe/react-spectrum';
+import { useNavigate } from 'react-router-dom';
+import DashboardLayout from '../../core/Layout/Layout.jsx';
+import DomainKeyForm from '../../forms/DomainKeyForm/DomainKeyForm.jsx';
+import Card from '../../core/Card/Card.jsx';
+import { useStore } from '../../../stores/global.js';
 
-const DashboardDataDeskLanding = () => (
-    <LandingLayout>
-     <h1>Landing</h1>
-    </LandingLayout>
-);
+const DashboardDataDeskLanding = () => {
+  const {
+    setDomainKey,
+    setGlobalUrl,
+    domainkey,
+  } = useStore();
+
+  let navigate = null;
+
+  try {
+    navigate = useNavigate();
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log('useNavigate not available');
+  }
+
+  return (
+    <DashboardLayout hasNavigation={false}>
+        <div style={{ width: '100%', marginTop: '4em' }}>
+            <div style={{ maxWidth: '500px', margin: 'auto' }}>
+                <h2>Welcome to DataDesk</h2>
+                <Divider />
+                <br />
+                <Card>
+                <DomainKeyForm
+                    onValidForm={({
+                      inputUrl: formGlobalKey,
+                      domainkey: formDomainKey,
+                    }) => {
+                      setGlobalUrl(formGlobalKey);
+                      setDomainKey(formDomainKey);
+                      navigate('/rum-dashboard');
+                    }}
+                />
+                <span>{domainkey}</span>
+                </Card>
+
+            </div>
+        </div>
+
+    </DashboardLayout>
+  );
+};
 
 export default DashboardDataDeskLanding;

--- a/src/components/views/DashboardDataDeskLanding/DashboardDataDeskLanding.stories.jsx
+++ b/src/components/views/DashboardDataDeskLanding/DashboardDataDeskLanding.stories.jsx
@@ -1,0 +1,14 @@
+import DashboardDataDeskLanding from './DashboardDataDeskLanding.jsx';
+
+export default {
+  title: 'Design System/Views/DashboardDataDeskLanding',
+  component: DashboardDataDeskLanding,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export const dashboardDataDeskLandingDefault = () => (
+    <DashboardDataDeskLanding />
+);

--- a/src/components/views/DashboardRUMPerformanceMonitor/DashboardRUMPerformanceMonitor.jsx
+++ b/src/components/views/DashboardRUMPerformanceMonitor/DashboardRUMPerformanceMonitor.jsx
@@ -1,17 +1,9 @@
 import { Grid, View } from '@adobe/react-spectrum';
-import { useState, useEffect } from 'react';
-import { DashboardQueryFilter } from '../../../controllers/Filters/DashboardQueryFilter.jsx';
 import DashboardLayout from '../../core/Layout/Layout.jsx';
 import LineChart from '../../charts/LineChart/LineChart.jsx';
 import './DashboardRUMPerformanceMonitor.css';
 
 const DashboardRUMPerformanceMonitor = () => {
-  const [data, setData] = useState([]);
-  const [fetchFlag, setFetchFlag] = useState(false);
-
-  useEffect(() => {
-    console.log('data has changed');
-  }, [data, fetchFlag]);
   const domain = 'www.adobe.com';
 
   const dataChart1 = [
@@ -78,18 +70,11 @@ const DashboardRUMPerformanceMonitor = () => {
     <DashboardLayout>
         <Grid
             areas={[
-              'sidebar chart1 chart2',
-              'sidebar chart3 chart4',
+              'chart1 chart2',
+              'chart3 chart4',
             ]}
-            columns={['.5fr', '6fr']} rows={['auto']} height="87vh" width="100vw" columnGap={'size-100'} id="chartview"
+            columns={['2fr', '2fr']} rows={['auto']} height="87vh" width="100vw" columnGap='size-100' id="chartview"
             >
-              <View gridArea="sidebar" height="100%">
-                <DashboardQueryFilter hasCheckpoint={true}
-                data={data} setter={setData} dataEndpoint={'rum-dashboard'}
-                apiEndpoint={'https://helix-pages.anywhere.run/helix-services/run-query@ci6232'}
-                dataFlag={fetchFlag} flagSetter={setFetchFlag}>
-                </DashboardQueryFilter>
-            </View>
             <View gridArea="chart1" height="100%">
                 <LineChart data={dataChart1}
                 title='(LCP) Largest Contentful Paint - 75p'

--- a/src/components/views/DashboardRUMView/RumDashboardMain.jsx
+++ b/src/components/views/DashboardRUMView/RumDashboardMain.jsx
@@ -1,8 +1,7 @@
 import { Grid, View, Flex } from '@adobe/react-spectrum';
 import { useState, useEffect } from 'react';
-import { DashboardQueryFilter } from '../../../controllers/Filters/DashboardQueryFilter';
+// import DashboardQueryFilter from '../../../controllers/Filters/DashboardQueryFilter';
 import { RumTableView } from './RumTableView';
-
 
 export function RumDashboardMain() {
   const [data, setData] = useState([]);
@@ -33,15 +32,14 @@ export function RumDashboardMain() {
   };
 
   return (
-        <Grid areas={['sidebar content1',
-          'sidebar content1']} columns={['.5fr', '6fr']} rows={['auto']} height="87vh" width="100%" columnGap={'size-100'} id='table_gridview'>
-            <View gridArea="sidebar" height="100%">
+        <Grid areas={['content1', 'content1']} columns={['1fr', '1fr']} rows={['auto']} height="87vh" width="100%" columnGap={'size-100'} id='table_gridview'>
+            {/* <View gridArea="sidebar" height="100%">
               <DashboardQueryFilter hasCheckpoint={true}
               data={data} setter={setData} dataEndpoint={'rum-dashboard'}
               apiEndpoint={'https://helix-pages.anywhere.run/helix-services/run-query@ci6232'}
               dataFlag={fetchFlag} flagSetter={setFetchFlag}>
               </DashboardQueryFilter>
-            </View>
+            </View> */}
 
             <View gridArea="content1" width="100%" height="100%" overflow="hidden">
               <Flex width="100%" height="100%">

--- a/src/stores/global.js
+++ b/src/stores/global.js
@@ -1,0 +1,55 @@
+import { create } from 'zustand';
+
+export const useStore = create((set) => ({
+  domainKey: null,
+  globalUrl: null,
+  setDomainKey: (value) => {
+    // save to localstorage
+
+    if (value) {
+      localStorage.setItem('domainKey', value);
+    }
+
+    set(() => ({ domainKey: value }));
+  },
+  setGlobalUrl: (value) => {
+    // save to localstorage
+
+    if (value) {
+      localStorage.setItem('globalUrl', value);
+    }
+    set(() => ({ globalUrl: value }));
+  },
+}));
+
+export const initStore = () => {
+  const {
+    setDomainKey,
+    setGlobalUrl,
+  } = useStore.getState();
+
+  // remove values from localstorage
+  localStorage.removeItem('domainKey');
+  localStorage.removeItem('globalUrl');
+
+  setDomainKey(null);
+  setGlobalUrl(null);
+};
+
+export const initializeStoreFromLocalStorage = () => {
+  const {
+    setDomainKey,
+    setGlobalUrl,
+  } = useStore.getState();
+
+  const domainKey = localStorage.getItem('domainKey');
+  const globalUrl = localStorage.getItem('globalUrl');
+
+  if (domainKey) {
+    setDomainKey(domainKey);
+  }
+
+  if (globalUrl) {
+    setGlobalUrl(globalUrl);
+  }
+};


### PR DESCRIPTION
This PR defines a flow to authenticate in app with domainKey, and scaffold a global store as replacement for parameters stored in window object.

I've commented the sidenav with filters, ideally they should be populated in the store.

Fix #49 #50 

- https://domainkey-landing--franklin-dashboard--adobe.hlx.page/
